### PR TITLE
249 highlight components

### DIFF
--- a/frontend/src/scene/ClickObjects.tsx
+++ b/frontend/src/scene/ClickObjects.tsx
@@ -1,22 +1,65 @@
-import { RootState, useThree } from "@react-three/fiber";
+import { RootState, useFrame, useThree } from "@react-three/fiber";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer";
+import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass";
+import { Object3D, Scene, Vector2 } from "three";
+import { useEffect, useRef } from "react";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass";
 
 function ClickObjects() {
   const state = useThree();
   const canvas = state.gl.domElement;
-  canvas.addEventListener("click", () => OnClick(state));
+  const composerRef = useRef<EffectComposer>();
+  const outlinePassRef = useRef<OutlinePass>();
+
+  useEffect(() => {
+    const composer = new EffectComposer(state.gl);
+    composerRef.current = composer;
+
+    const renderPass = new RenderPass(state.scene, state.camera);
+    composer.addPass(renderPass);
+
+    const outlinePass = new OutlinePass(new Vector2(state.size.width, state.size.height), state.scene, state.camera);
+    composer.addPass(outlinePass);
+    outlinePassRef.current = outlinePass;
+
+    canvas.addEventListener("click", () => OnClick(state, outlinePass));
+  }, [state, canvas]);
+
+  useFrame(() => {
+    if (composerRef.current) {
+      composerRef.current.render();
+    }
+  }, 1);
+
+
 
   return null;
 }
 
-function OnClick(state: RootState) {
+function OnClick(state: RootState, outlinePass: OutlinePass) {
   const matched = state.raycaster.intersectObjects(state.scene.children);
 
   if (matched.length > 0) {
     const first = matched[0];
+    const rootObject = getRootObject(first.object);
 
     // Highlight
-    first.object.scale.set(1.2, 1.2, 1.2);
+    outlinePass.selectedObjects = [rootObject];
   }
 }
+
+function getRootObject(object: Object3D): Object3D {
+  let obj = object;
+  while (obj.parent && !(obj.parent instanceof Scene)) {
+    obj = obj.parent;
+
+    if (Object.keys(obj.userData).length > 0 && obj.userData["topic"]) {
+      return obj;
+    }
+  }
+
+  return object;
+}
+
 
 export default ClickObjects;

--- a/frontend/src/scene/ClickObjects.tsx
+++ b/frontend/src/scene/ClickObjects.tsx
@@ -1,8 +1,11 @@
 import { RootState, useFrame, useThree } from "@react-three/fiber";
+// @ts-expect-error Source is javascript
 import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer";
+// @ts-expect-error Source is javascript
 import { OutlinePass } from "three/examples/jsm/postprocessing/OutlinePass";
 import { Object3D, Scene, Vector2 } from "three";
 import { useEffect, useRef } from "react";
+// @ts-expect-error Source is javascript
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass";
 
 function ClickObjects() {
@@ -48,6 +51,8 @@ function OnClick(state: RootState, outlinePass: OutlinePass) {
   }
 }
 
+// Returns the root object which has custom annotations or otherwise the object
+// the initial object.
 function getRootObject(object: Object3D): Object3D {
   let obj = object;
   while (obj.parent && !(obj.parent instanceof Scene)) {


### PR DESCRIPTION
As of right now, this is not fully functional. On most parts you can click and the correct part will be highlighted. However, on parts of the "Querausleger" this is not possible. My best guess is that this is due to the grouping we do in Blender.
It took me many hours to get this to work, even though it seems pretty simple. That's why I suggest we leave it that way for now.